### PR TITLE
Update Two for Tunestr source feed URL to podhome.fm

### DIFF
--- a/docs/TFT-music-playlist.xml
+++ b/docs/TFT-music-playlist.xml
@@ -3,8 +3,8 @@
     <author>ChadF</author>
     <title>Two for Tunestr Music Playlist</title>
     <description>Every music reference from Two for Tunestr</description>
-    <link>https://feeds.rssblue.com/too-angry-cunts</link>
-    <podcast:txt purpose="source-feed">https://feeds.rssblue.com/too-angry-cunts</podcast:txt>
+    <link>https://serve.podhome.fm/rss/fafd2bfc-98ac-5010-9fcb-7403abfd420a</link>
+    <podcast:txt purpose="source-feed">https://serve.podhome.fm/rss/fafd2bfc-98ac-5010-9fcb-7403abfd420a</podcast:txt>
     <language>en</language>
     <pubDate>Wed, 25 Mar 2026 07:52:36 GMT</pubDate>
     <lastBuildDate>Wed, 25 Mar 2026 07:52:36 GMT</lastBuildDate>

--- a/docs/upbeats-music-playlist.xml
+++ b/docs/upbeats-music-playlist.xml
@@ -4,7 +4,7 @@
     <title>UpBeats Music Playlist</title>
     <description>Every music reference from UpBEATs</description>
     <link>https://upbeatspodcast.com/</link>
-    <podcast:txt purpose="source-feed">https://feeds.rssblue.com/upbeats</podcast:txt>
+    <podcast:txt purpose="source-feed">https://serve.podhome.fm/rss/3aebb7a8-5942-5ee7-a148-8bdc14f1f3d4</podcast:txt>
     <language>en</language>
     <pubDate>Tue, 24 Mar 2026 07:53:27 GMT</pubDate>
     <lastBuildDate>Tue, 24 Mar 2026 07:53:27 GMT</lastBuildDate>


### PR DESCRIPTION
The feed moved from rssblue.com to serve.podhome.fm.

https://claude.ai/code/session_01LbyerfdyEDsDBCb1UMK85s